### PR TITLE
fix: make --if-present flag work for both packages managers

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -77,7 +77,7 @@ runs:
 
     - name: 👥 Copy ArcGIS assets
       shell: bash
-      run: ${{ steps.package-manager.outputs.name }} run copy:arcgis --if-present
+      run: ${{ steps.package-manager.outputs.name }} run --if-present copy:arcgis
 
     - name: 🗝️ Authenticate to Google Cloud
       id: auth


### PR DESCRIPTION
I've tested this with pnpm and npm. Prior to this change, PNPM returns an error if the command does not exist.