### PR TITLE
feat: add pnpm-version input to support pinned version overrides

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,10 @@ inputs:
     description: The version of node to use
     required: false
     default: "lts/*"
+  pnpm-version:
+    description: "The version of PNPM to install"
+    required: false
+    default: "11"
 
 runs:
   using: composite
@@ -69,7 +73,7 @@ runs:
       if: steps.package-manager.outputs.name == 'pnpm'
       uses: pnpm/action-setup@v6
       with:
-        version: 11
+        version: ${{ inputs.pnpm-version }}
 
     - name: ⎔ Setup Node.js
       uses: actions/setup-node@v6


### PR DESCRIPTION
Add a new configurable `pnpm-version` input to the workflow configuration, mirroring the behavior of the existing `node-version` input. Sets the current working version (`11`) as the default to prevent upstream package manager regressions. Resolves #120